### PR TITLE
Docker Trust

### DIFF
--- a/.exports
+++ b/.exports
@@ -28,4 +28,5 @@ export GDK_SCALE=2
 export GDK_DPI_SCALE=0.5
 export QT_DEVICE_PIXEL_RATIO=2
 
-export DOCKER_CONTENT_TRUST=1
+# Must be disabled to allow gcr.io to function correctly
+export DOCKER_CONTENT_TRUST=0


### PR DESCRIPTION
Disable docker content trust to allow pulling from gcr.io.