### PR TITLE
Force Push Refresh

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -6,6 +6,9 @@
   pp = pull --prune
   ppc = !git pp && git bclean
 
+  # Reset a branch that may have been force pushed to the correct remote HEAD.
+  fpr = !git rev-parse --abbrev-ref HEAD | xargs -I {} /bin/bash -c 'git fetch origin {} && git reset --soft origin/{}' 
+
 
 [apply]
 


### PR DESCRIPTION
Adding a new command that can safely reset a force pushed branch to the
correct HEAD.

```sh
$ git fpr
```