### PR TITLE
Path Expansion Bug

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -28,48 +28,46 @@ shopt -s histappend                         # Append rather than overwrite
 # ======== Prompt setup ===========================
 #
 # Expand any symbolic links in the specified pathname and convert to absolute path
-function realpath() {
-  f=$@
-  if [ -d "$f" ]; then
+realpath() {
+  f="$1"
+  if [[ -d "$f" ]]; then
     base=""
     dir="$f"
   else
     base="/$(basename "$f")"
-    dir=$(dirname "$f")
+    dir="$(dirname "$f")"
   fi
 
   dir=$(cd "$dir" && /bin/pwd)
   echo "$dir$base"
 }
 
-# Set prompt path to max 2 levels for best compromise of readability and usefulness
 promptpath () {
-  realpwd=$(realpath $PWD)          # Absolute path
-  realhome=$(realpath $HOME)
+  realpwd="$(realpath "$PWD")"
+  realhome="$(realpath "$HOME")"
 
   # if we are in the home directory, show tilde if possible
-  if echo $realpwd | grep -q "^$realhome"; then
-    path=$(echo $realpwd | sed "s|^$realhome|\~|")
-    if [ "$path" = "~" ] || [ "$(dirname "$path")" = "~" ]; then
-      echo $path
+  if echo "${realpwd}" | grep -q "^${realhome}"; then
+    path="$(echo "${realpwd}" | sed "s|^${realhome}|\~|")"
+    if [ "${path}" = "~" ] || [ "$(dirname "${path}")" = "~" ]; then
+      echo "${path}"
     else
-      echo $(basename $(dirname "$path"))/$(basename "$path")
+      echo "$(basename "$(dirname "$path")")/$(basename "$path")"
     fi
     return
   fi
 
-  path_dir=$(dirname $PWD)
+  path_dir=$(dirname "${PWD}")
   # if our parent dir is a top-level directory, don't mangle it
-  if [ $(dirname $path_dir) = "/" ]; then
-    echo $PWD
+  if [ "$(dirname "$path_dir")" = "/" ]; then
+    echo "${PWD}"
   else
-    path_parent=$(basename "$path_dir")
-    path_base=$(basename "$PWD")
+    path_parent="$(basename "${path_dir}")"
+    path_base="$(basename "${PWD}")"
 
     echo "${path_parent}/${path_base}"
   fi
 }
-
 
 # Terminal colours - must use \[ and \] to tell readline about them, so bash line editing works
 inverse="\[$(tput smso)\]"


### PR DESCRIPTION
Fixes a bug where a subpath where the parent directory contained a space
would cause bash errors to be logged in the terminal.