### PR TITLE
Remove Heureka Git

### DIFF
--- a/.functions
+++ b/.functions
@@ -54,10 +54,3 @@ man() {
 		man "$@"
 }
 
-# Set my heureka commit credentials
-git-config-heureka() {
-
-    git config user.name "Cameron Rollheiser"
-    git config user.email "cameron.rollheiser@heurekasoftware.com"
-
-}


### PR DESCRIPTION
Removing the function to automatically set my heureka credentials. This
is  a bad practice anyway.