### PR TITLE
Fix Google Cloud SDK Install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ tools:
 	# Install Google Cloud SDK
 	if [ ! -d "$(HOME)/tools/google-cloud-sdk" ]; then \
 		curl https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=$(HOME)/tools; \
-		gcloud components install --quiet kubectl; \
-		gcloud components update --quiet; \
+		$(HOME)/tools/google-cloud-sdk/bin/gcloud components install --quiet kubectl; \
+		$(HOME)/tools/google-cloud-sdk/bin/gcloud components update --quiet; \
 	fi;
 	# Install node
 	if [ ! -d "$(HOME)/tools/node" ]; then \


### PR DESCRIPTION
The google cloud sdk install wasn't using the correct path, this will
make the install work correctly without needing to reset the path.