### PR TITLE
Python Linting + Sponge

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -24,5 +24,7 @@
     "eslint.enable": true,
     "[javascriptreact]": {
         "editor.tabSize": 2
-    }
+    },
+    "python.linting.pylintUseMinimalCheckers": false,
+    "editor.multiCursorModifier": "ctrlCmd"
 }

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -94,6 +94,7 @@ base() {
     scdaemon \
     shellcheck \
     silversearcher-ag \
+    moreutils \
     ssh \
     strace \
     sudo \


### PR DESCRIPTION
Enable python linting by default and add sponge as a command line tool
because its super useful.