### PR TITLE
Touchpad Settings

### DIFF
--- a/etc/X11/xorg.conf.d/50-synaptics-clickpad.conf
+++ b/etc/X11/xorg.conf.d/50-synaptics-clickpad.conf
@@ -1,0 +1,22 @@
+Section "InputClass"
+    Identifier "touchpad"
+    Driver "synaptics"
+    MatchIsTouchpad "on"
+    # Enables Palm Detection to prevent bad clicks
+    # This seems to work on PS/2, but not on i2c
+    Option "PalmDetect" "1"
+    Option "PalmMinWidth" "8"
+    Option "PalmMinZ" "100"
+    # Enable clickpad support
+    Option "ClickPad" "true"
+    # Disables Tap to click
+    Option "MaxTapTime" "0"
+    # Coasting
+    Option "CoastingSpeed" "20.0"
+    Option "CoastingFriction" "50000.0"
+    # No Button Areas
+    Option "SoftButtonAreas" "0 0 0 0 0 0 0 0"
+    # No Right Mouse button, use two finger click
+    Option "RightButtonAreaLeft" "0"
+    Option "RightButtonAreaTop" "0"
+EndSection


### PR DESCRIPTION
Fix coasting settings for touchpad so that chrome doesn't zoome like
crazy, remove the soft rght click button, and increase palm detection.