### PR TITLE
Default Syncthing Service

### DIFF
--- a/etc/systemd/system/syncthing@.service
+++ b/etc/systemd/system/syncthing@.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 User=%i
-ExecStart=/usr/local/bin/syncthing -no-restart -logflags=0
+ExecStart=/usr/local/bin/syncthing -no-browser -no-restart -logflags=0
 Restart=on-failure
 SuccessExitStatus=2 3 4
 RestartForceExitStatus=3 4


### PR DESCRIPTION
Adding the default syncthing server, the -no-browser flag does not
disable the ui as I expected. It just stops syncthing from opening a new
browser window.