### PR TITLE
Git Config

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -110,7 +110,7 @@
   program = gpg2
 
 [includeIf "gitdir:~/code/personal/"]
-  path = ~/.gitconfig.personal
+  path = .gitconfig.personal
 
 [includeIf "gitdir:~/code/invision/"]
-  path = ~/.gitconfig.invision
+  path = .gitconfig.invision


### PR DESCRIPTION
Git conditional include are relative to the global gitconfig so there is
no need to specify the home directory.