### PR TITLE
Disable Super+P on Ubuntu 16.04

### DIFF
--- a/bin/disable-super-p.sh
+++ b/bin/disable-super-p.sh
@@ -24,6 +24,7 @@ install_linux() {
     echo 'Exiting'
   else
     sudo gconftool-2 -t boolean -s /apps/gnome_settings_daemon/plugins/xrandr/active false
+    sudo dconf write /org/gnome/settings-daemon/plugins/media-keys/video-out "''"
     echo 'Disabled'
   fi
 }


### PR DESCRIPTION
Disable Super+P on latest version of Ubuntu.